### PR TITLE
removing beginTransaction, fix restore state after rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,12 @@ The following keys are additional commands that allow you to interact with the m
  - `reset`:
     - whatever object as argument
     - will reset the database   
- - `begin_transaction`:
-    - whatever object as argument
-    - will start a database transaction (useful when trying to build unit tests around transaction reversions)
-    - it basically backs up the database so that ic can be rolledback to the backedup state if the transaction reverts
  - `rollback_transaction`:
     - whatever object as argument
-    - will restore the backup made via `begin_transaction`
+    - will restore the backup made in the previous `commit_transaction`
  - `commit_transaction`:
     - whatever object as argument
-    - will clear the backup made via `begin_transaction` (hence make it impossible to rollback)
+    - will save a backup of the actual state of the database (useful when trying to build unit tests around transaction reversions)
 
 Example for setting the contract id in an AssemblyScript Koinos smart contract:
 ```js

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,7 +18,6 @@ const RESET_KEY = new TextEncoder('utf-8').encode('reset')
 const LOGS_KEY = new TextEncoder('utf-8').encode('logs')
 const EVENTS_KEY = new TextEncoder('utf-8').encode('events')
 const EXIT_CODE_KEY = new TextEncoder('utf-8').encode('exit_code')
-const BEGIN_TRANSACTION_KEY = new TextEncoder('utf-8').encode('begin_transaction')
 const ROLLBACK_TRANSACTION_KEY = new TextEncoder('utf-8').encode('rollback_transaction')
 const COMMIT_TRANSACTION_KEY = new TextEncoder('utf-8').encode('commit_transaction')
 
@@ -39,7 +38,6 @@ module.exports = {
   LOGS_KEY,
   EVENTS_KEY,
   EXIT_CODE_KEY,
-  BEGIN_TRANSACTION_KEY,
   ROLLBACK_TRANSACTION_KEY,
   COMMIT_TRANSACTION_KEY
 }

--- a/src/database.js
+++ b/src/database.js
@@ -11,6 +11,7 @@ class Database {
 
   initDb (arr = []) {
     this.db = new SoMap(arr, this.comparator)
+    this.commitTransaction();
   }
 
   comparator (a, b) {
@@ -23,15 +24,8 @@ class Database {
     }
   }
 
-  beginTransaction () {
-    this.backupDb = new SoMap(this.db)
-  }
-
   commitTransaction () {
-    if (this.backupDb) {
-      this.backupDb.clear()
-      this.backupDb = null
-    }
+    this.backupDb = new SoMap(this.db)
   }
 
   rollbackTransaction () {


### PR DESCRIPTION
This PR gives more relevance to `MockVM.commitTransaction` instead of `MockVM.beginTransaction`, which is more intuitive and easy to use by developers. Example:

Before:
```
contract.transfer(...);

Mock.beginTransaction();
expect(() => {...}).toThrow();

Mock.beginTransaction(); // if the test has several expect().toThrow() it's required to beginTransaction again
expect(() => {...}).toThrow();
```

After:
```
contract.transfer(...);
Mock.commitTransaction(); // backup saved

expect(() => {...}).toThrow();
expect(() => {...}).toThrow();
```

This PR also restore the state of more variables in the metadata space which should not be rolled back.